### PR TITLE
Complete task with "star"

### DIFF
--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: 0x696d/hipster-frontend:v0.0.1
+    name: frontend
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "192.168.1.100"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "192.168.1.101"
+    - name: CART_SERVICE_ADDR
+      value: "192.168.1.106"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "192.168.1.102"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "192.168.1.103"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "192.168.1.104"
+    - name: AD_SERVICE_ADDR
+      value: "192.168.1.105"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: 0x696d/hipster-frontend:v0.0.1
+    name: frontend
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе основного ДЗ сделано:
 - Собран Docker образ `0x696d/kubernetes-intro:0.0.2`
 - Создан манифест `web-pod.yaml` запускающий pod с собранным образом

## В процессе задания со * сделано:
 - Собран Docker образ `0x696d/hipster-frontend:v0.0.1` из [Dockerfile](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/src/frontend/Dockerfile)
 - Создан манифест `frontend-pod.yaml` ad-hoc командой
 - Найдена причина почему запущенный pod в статусе `Error`
 - Создан манифест `frontend-pod-healthy.yaml` содержащий исправления

## Решение задания со *:
При первом запуске манифеста `frontend-pod.yaml` смотрим вывод `kubectl get pod/frontend`: 
```sh
kubectl get pod/frontend
NAME       READY   STATUS   RESTARTS   AGE
frontend   0/1     Error    0          66s
```
Cмотрим логи `kubectl logs pod/frontend`:
```sh
panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set

goroutine 1 [running]:
main.mustMapEnv(0xc0002a0bb0, 0xb03c4a, 0x1c)
	/go/src/github.com/GoogleCloudPlatform/microservices-demo/src/frontend/main.go:248 +0x10e
main.main()
	/go/src/github.com/GoogleCloudPlatform/microservices-demo/src/frontend/main.go:106 +0x3e9
```
Не хватает переменной окружения. Смотрим 106 строчку `main.go`:
```go
        mustMapEnv(&svc.productCatalogSvcAddr, "PRODUCT_CATALOG_SERVICE_ADDR")
        mustMapEnv(&svc.currencySvcAddr, "CURRENCY_SERVICE_ADDR")
        mustMapEnv(&svc.cartSvcAddr, "CART_SERVICE_ADDR")
        mustMapEnv(&svc.recommendationSvcAddr, "RECOMMENDATION_SERVICE_ADDR")
        mustMapEnv(&svc.checkoutSvcAddr, "CHECKOUT_SERVICE_ADDR")
        mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_SERVICE_ADDR")
        mustMapEnv(&svc.adSvcAddr, "AD_SERVICE_ADDR")
```
Тут задается несколько переменных окружения и скорее всего пока их все не задать, контейнер так и не стартанет.
"Гуглим" как в манифесте pod'a задать переменные окружения, задаем, и снова запускаем:
```sh
kubectl delete pod frontend && kubectl apply -f frontend-pod-healthy.yaml && kubectl get pod/frontend -w
pod "frontend" deleted
pod/frontend created
NAME       READY   STATUS              RESTARTS   AGE
frontend   0/1     ContainerCreating   0          0s
frontend   1/1     Running             0          2s
^C
```

## Как запустить проект:
 - Запустить команду `kubectl apply -f web-pod.yaml` в директории `kubernetes-intro`

## Как проверить работоспособность:
 - Запустить команду `kubectl get pod web`, статус должен быть `Running`
 - Запустить команду `kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`
 - Открыть в браузере http://localhost:8000

## PR checklist:
 - [x] Выставлен label с номером домашнего задания

